### PR TITLE
refactoring to make writing tests easier

### DIFF
--- a/UpdateUserHttp.Tests/UnitTest1.cs
+++ b/UpdateUserHttp.Tests/UnitTest1.cs
@@ -42,6 +42,20 @@ namespace UpdateUserHttp.Tests
             var result = await UpdateUser.Run(req: request, log: log);
             Assert.AreEqual("\"E0NoUserID\"", result.Content.ReadAsStringAsync().Result);
         }
+        [TestMethod]
+        public async Task Request_Query_With_empty_UserID()
+        {
+            // Create HttpRequestMessage
+            var data = "{\"user\": { \"userID\": \"\" } }";
+            var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/");
+            request.Content = new StringContent(data, Encoding.UTF8, "application/json");
+            var httpConfig = new HttpConfiguration();
+            request.SetConfiguration(httpConfig);
+
+            UpdateUser._graphClientWrapper = new GraphClientMock("No User ID");
+            var result = await UpdateUser.Run(req: request, log: log);
+            Assert.AreEqual("\"E0NoUserID\"", result.Content.ReadAsStringAsync().Result);
+        }
 
         [TestMethod]
         public async Task Request_Query_With_Invalid_ID()

--- a/UpdateUserHttp.Tests/UnitTest1.cs
+++ b/UpdateUserHttp.Tests/UnitTest1.cs
@@ -23,6 +23,7 @@ namespace UpdateUserHttp.Tests
             var httpConfig = new HttpConfiguration();
             request.SetConfiguration(httpConfig);
 
+            UpdateUser._graphClientWrapper = new GraphClientMock(null);
             var result = await UpdateUser.Run(req: request, log: log);
             Assert.AreEqual("\"Finished\"", result.Content.ReadAsStringAsync().Result);
         }
@@ -37,6 +38,7 @@ namespace UpdateUserHttp.Tests
             var httpConfig = new HttpConfiguration();
             request.SetConfiguration(httpConfig);
 
+            UpdateUser._graphClientWrapper = new GraphClientMock("No User ID");
             var result = await UpdateUser.Run(req: request, log: log);
             Assert.AreEqual("\"E0NoUserID\"", result.Content.ReadAsStringAsync().Result);
         }
@@ -54,6 +56,7 @@ namespace UpdateUserHttp.Tests
             var httpConfig = new HttpConfiguration();
             request.SetConfiguration(httpConfig);
 
+            UpdateUser._graphClientWrapper = new GraphClientMock("Invalid ID");
             var result = await UpdateUser.Run(req: request, log: log);
             Assert.AreEqual("\"E1BadRequest\"", result.Content.ReadAsStringAsync().Result);
         }

--- a/UpdateUserHttp/UpdateUser.cs
+++ b/UpdateUserHttp/UpdateUser.cs
@@ -109,7 +109,7 @@ namespace UpdateUserHttp
 
             // Check if userID is passed
             // return BadRequest if not present
-            if (userID == null)
+            if (String.IsNullOrEmpty(userID))
             {
                 return req.CreateResponse(HttpStatusCode.BadRequest, "E0NoUserID");
             }

--- a/UpdateUserHttp/UpdateUser.cs
+++ b/UpdateUserHttp/UpdateUser.cs
@@ -20,12 +20,28 @@ namespace UpdateUserHttp
 
   public interface IGraphClientWrapper
   {
-    System.Threading.Tasks.Task<Microsoft.Graph.User> updateUser( String userID, User guestUser );
+    Task<object> updateUser( String userID, User guestUser );
+  }
+  
+  public class GraphClientMock : IGraphClientWrapper
+  {
+      private readonly String _result;
+
+      public GraphClientMock( String result )
+      {
+          _result = result;
+      }
+
+      public async Task<object> updateUser( String userID, User guestUser )
+      {
+          var mockResult = Task<object>.Run( () => {return _result;} );
+          return await mockResult;
+      }
   }
 
     public static class UpdateUser
     {
-      private static IGraphClientWrapper _graphClientWrapper;
+      public static IGraphClientWrapper _graphClientWrapper;
 
         [FunctionName("UpdateUser")]
         public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]HttpRequestMessage req, TraceWriter log)
@@ -123,7 +139,7 @@ namespace UpdateUserHttp
         _graphClient = graphClient;
       }
 
-      public async System.Threading.Tasks.Task<Microsoft.Graph.User> updateUser( String userID, User guestUser )
+      public async Task<object> updateUser( String userID, User guestUser )
       {
         return await _graphClient.Users[userID]
                   .Request()

--- a/UpdateUserHttp/UpdateUser.cs
+++ b/UpdateUserHttp/UpdateUser.cs
@@ -25,6 +25,8 @@ namespace UpdateUserHttp
 
     public static class UpdateUser
     {
+      private static IGraphClientWrapper _graphClientWrapper;
+
         [FunctionName("UpdateUser")]
         public static async Task<HttpResponseMessage> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]HttpRequestMessage req, TraceWriter log)
         {
@@ -96,9 +98,13 @@ namespace UpdateUserHttp
                 return req.CreateResponse(HttpStatusCode.BadRequest, "E0NoUserID");
             }
 
-            var authResult = GetOneAccessToken();
-            IGraphClientWrapper graphClient = new GraphClientWrapper(GetGraphClient(authResult));
-            var result = ChangeUserInfo(graphClient, log, userID, jobTitle, firstName, lastName, displayName, businessPhones, streetAddress, department, city, province, postalcode, mobilePhone, country);
+            if (_graphClientWrapper == null)
+            {
+              var authResult = GetOneAccessToken();
+              _graphClientWrapper = new GraphClientWrapper(GetGraphClient(authResult));
+            }
+
+            var result = ChangeUserInfo(_graphClientWrapper, log, userID, jobTitle, firstName, lastName, displayName, businessPhones, streetAddress, department, city, province, postalcode, mobilePhone, country);
 
             if (result.Result != null)
             {

--- a/UpdateUserHttp/UpdateUser.cs
+++ b/UpdateUserHttp/UpdateUser.cs
@@ -85,23 +85,21 @@ namespace UpdateUserHttp
 
             // Check if userID is passed
             // return BadRequest if not present
-            if (userID != null)
-            {
-                var authResult = GetOneAccessToken();
-                var graphClient = GetGraphClient(authResult);
-                var result = ChangeUserInfo(graphClient, log, userID, jobTitle, firstName, lastName, displayName, businessPhones, streetAddress, department, city, province, postalcode, mobilePhone, country);
-
-                if (result.Result == null)
-                {
-                    return req.CreateResponse(HttpStatusCode.OK, "Finished");
-                } else
-                {
-                    return req.CreateResponse(HttpStatusCode.BadRequest, "E1BadRequest");
-                }
-            } else
+            if (userID == null)
             {
                 return req.CreateResponse(HttpStatusCode.BadRequest, "E0NoUserID");
             }
+
+            var authResult = GetOneAccessToken();
+            var graphClient = GetGraphClient(authResult);
+            var result = ChangeUserInfo(graphClient, log, userID, jobTitle, firstName, lastName, displayName, businessPhones, streetAddress, department, city, province, postalcode, mobilePhone, country);
+
+            if (result.Result != null)
+            {
+                return req.CreateResponse(HttpStatusCode.BadRequest, "E1BadRequest");
+            }
+
+            return req.CreateResponse(HttpStatusCode.OK, "Finished");
         }
 
     public static string GetOneAccessToken()


### PR DESCRIPTION
Starting with a small readability thing with error checking, ironically enough the diff is not that easy to read...

 * added a wrapper for the api client which can be mocked for unit test
 * unit test updated to use the mock api client wrapper

 * added a test for an empty user ID being passed

closes #4 